### PR TITLE
Simplify BitStuck

### DIFF
--- a/randomsanitystat.go
+++ b/randomsanitystat.go
@@ -94,25 +94,24 @@ func Repeated(b []byte) bool {
 	return false
 }
 
-// BitStuck returns true and which bit is stuck if b contains
-// long runs of bytes with the same bit set or unset
-func BitStuck(b []byte) (bool, uint) {
+// BitStuck returns true if a bit in b is always set or unset
+// (and b is 64 or more bytes long)
+func BitStuck(b []byte) bool {
 	if len(b) < 64 {
-		return false, 0
+		return false
 	}
-	// Create a new byte array with all the low bits,
-	// etc. Then use Repeated to look for runs of
-	// zero or one.
-	for bit := uint(0); bit < uint(8); bit++ {
-		bb := make([]byte, (len(b)+7)/8)
-		for i, v := range b {
-			bb[i/8] |= ((v >> bit) & 0x01) << uint(i%8)
-		}
-		if Repeated(bb) {
-			return true, bit
-		}
+
+	allOr := byte(0)
+	allAnd := byte(0xff)
+
+	for _, v := range b {
+		allOr |= v
+		allAnd &= v
 	}
-	return false, 0
+	if allOr != 0xff || allAnd != 0x0 {
+		return true
+	}
+	return false
 }
 
 // DecimalHex detects confusing decimal and hex (no A-F hex digits)
@@ -142,8 +141,7 @@ func LooksRandom(b []byte) (bool, string) {
 	if DecimalHex(b) {
 		return false, "Decimal digits as hex"
 	}
-	stuck, _ := BitStuck(b)
-	if stuck {
+	if BitStuck(b) {
 		return false, "Bit stuck"
 	}
 

--- a/randomsanitystat_test.go
+++ b/randomsanitystat_test.go
@@ -59,7 +59,7 @@ func TestLooksRandom(t *testing.T) {
 		{"3939393939393939", false},
 		{"ff393939393939393939bb", false},
 
-		// stuck bits tests (need 64 bytes or more)
+		// stuck bits tests (need 64 bytes for one bit set)
 		{"136d3d153516244b2a366d7b401131523d453b701f4b7c6d39480710561b5e0a136d3d153516244b2a366d7b401131523d453b701f4b7c6d39480710561b5e0a", false}, // 0x80 bit unset
 		{"13adbd95b516248baa36ad3b8011b1123d053bb09f0b3c2db9080790961b1e0a13adbd95b516248baa36ad3b8011b1123d053bb09f0b3c2db9080790961b1e0a", false}, // 0x40 bit unset
 		{"13cd9d95951604cb8a16cd5bc01191521d451bd09f4b5c4d99480790d61b5e0a13cd9d95951604cb8a16cd5bc01191521d451bd09f4b5c4d99480790d61b5e0a", false}, // 0x20 bit unset
@@ -110,7 +110,6 @@ func TestLooksRandom(t *testing.T) {
 		{"4724b307af612288395831874016ede4f3ba2d41df40c3884f1ff1b9c05ac3", true},
 		{"13edbd95b51624cbaa36ed7bc011b1523d453bf09f4b7c6db9480790d61b5e0a", true},
 	}
-
 	for _, test := range tests {
 		b, err := hex.DecodeString(strings.Replace(test.hexbytes, " ", "", -1))
 		if err != nil {


### PR DESCRIPTION
Simpler, faster code.

goapp test -bench=. .  results on my OSX desktop machine:
 Before: 15,000 ns/op
 After: 10,000 ns/op